### PR TITLE
Story - Seperate serialized types. Improve JSDocs. Improve README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@
 ## Overview
 
 GoodFlow improves how you do errors in Javascript:
-* Emit and handle errors in a flat, Go-like way, avoiding endless nested try-catch blocks and use of mutable `let` variables.
+* Emit and handle errors in a flat, Go-like way, avoiding nested try-catch blocks and use of mutable `let` variables.
 * Nest errors with inner errors to attach informative context.
 * Print errors to console beautifully.
 * Serialize errors to make it a [DTO](https://en.wikipedia.org/wiki/Data_transfer_object) (e.g. to make it JSON-serializable).
 
-## Usage
+## Usage Overview
 
 ```typescript
 import { createGFError, GFResult } from 'good-flow'
@@ -54,9 +54,39 @@ if (err != null) {
 exit(0)
 ```
 
+## Serialization
+
+Errors can be serialized, which converts them to a form that contains no non-serializable data, such as functions. This enables them to be, for example, JSON-serializable and sent over a network as a DTO.
+
+To create and serialize an error (e.g. server-side):
+
+```typescript
+import { createGFError } from 'good-flow'
+
+const err = createGFError('This is an error')
+const serializedErr = err.serialize()
+const errJson = JSON.stringify(serializedErr)
+```
+
+For the client-side, types for a serialized `GFError` are available seperately at `good-flow/lib/serialized` such that Node.js-only packages such as `colors` are not co-imported along (which would cause build/bundle issues for the web). For example (e.g. client-side):
+
+```typescript
+import { SerializedGFError } from 'good-flow/lib/serialized'
+
+type MyApiResponse<TData> = { data: TData, err: SerializedGFError }
+```
+
 ## Logging
 
-Use `GFError.toLogString` to serialize a GoodFlow error to a console-loggable string. A preview of this output for a relatively complex error:
+Errors can be logged to a Node.js console. For example:
+
+```typescript
+const err = createGFError('This is an error')
+err.log() // Equivalent to console.log(err.toLogString())
+err.log({ outlet: 'error' }) // // Equivalent to console.error(err.toLogString())
+```
+
+A preview of how errors log to console by default:
 
 ![Logging Preview](./img/img1.png)
 
@@ -66,4 +96,4 @@ See [./contributing/development.md](./contributing/development.md)
 
 ---
 
-If you found this package delightful, feel free to [buy me a coffee](https://www.buymeacoffee.com/samhuk) ✨
+If you would like to support the development of GoodFlow, feel free to [sponsor me on GitHub](https://github.com/sponsors/samhuk) or [buy me a coffee](https://www.buymeacoffee.com/samhuk) ✨

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "good-flow",
-  "version": "0.0.13",
+  "version": "0.0.14-beta0",
   "description": "Improve how you do Javascript errors",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "good-flow",
-  "version": "0.0.14-beta0",
+  "version": "0.0.14",
   "description": "Improve how you do Javascript errors",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/good-flow/advice/serialize/index.ts
+++ b/src/good-flow/advice/serialize/index.ts
@@ -1,6 +1,7 @@
 import { normalizeGFString } from '../../string'
 import { GFAdvice, GFTip } from '../types'
-import { SerializedGFAdvice, SerializedGFTip, SerializeGFAdviceOptions } from './types'
+import { SerializedGFAdvice, SerializedGFTip } from '../serialized/types'
+import { SerializeGFAdviceOptions } from './types'
 
 const serializeTip = (tip: GFTip, options?: SerializeGFAdviceOptions): SerializedGFTip => {
   if (typeof tip !== 'object')

--- a/src/good-flow/advice/serialize/types.ts
+++ b/src/good-flow/advice/serialize/types.ts
@@ -1,0 +1,6 @@
+export type SerializeGFAdviceOptions = {
+  /**
+   * @default false
+   */
+  disableColors?: boolean
+}

--- a/src/good-flow/advice/serialized/types.ts
+++ b/src/good-flow/advice/serialized/types.ts
@@ -1,10 +1,3 @@
-export type SerializeGFAdviceOptions = {
-  /**
-   * @default false
-   */
-  disableColors?: boolean
-}
-
 export type SerializedGFTip = string | { msg: string, url?: string }
 
 export type SerializedGFTips = SerializedGFTip | SerializedGFTip[]

--- a/src/good-flow/error/identification.ts
+++ b/src/good-flow/error/identification.ts
@@ -1,0 +1,29 @@
+import { SerializedGFError } from './serialized/types'
+import { GFError } from './types'
+
+export const GF_ERROR_IDENTIFIER_PROP_NAME = '__gfError'
+
+/**
+ * Asserts that the provided error is a `GFError` and not a native JS `Error` instance.
+ *
+ * @example
+ * isGFError(new Error()) // false
+ * isGFError(createGFError(...)) // true
+ */
+export const isGFError = (error: GFError | Error): error is GFError => (
+  GF_ERROR_IDENTIFIER_PROP_NAME in error
+)
+
+/**
+ * Asserts that the provided error is a `SerializedGFError` and not a native JS `Error` instance or something else.
+ *
+ * Note: This works by determining if the given error has a `msg` property, as this is present
+ * for a `SerializedGFError` object but not for native JS `Error` objects.
+ *
+ * @example
+ * isSerializedGFError({ name: 'ENOENT', message: 'File not found', ... }) // false
+ * isSerializedGFError(createGFError(...).serialize()) // true
+ */
+export const isSerializedGFError = (error: SerializedGFError | Error): error is SerializedGFError => (
+  'msg' in error
+)

--- a/src/good-flow/error/index.ts
+++ b/src/good-flow/error/index.ts
@@ -1,14 +1,8 @@
 import StackUtils from 'stack-utils'
 import { GFString } from '../string/types'
-import { serialize } from './serialization'
+import { serialize } from './serialize'
 import { toLogString } from './toLogString'
 import { GFError, GFErrorOptions, StackTrace } from './types'
-
-export const GF_ERROR_IDENTIFIER_PROP_NAME = '__gfError'
-
-export const isGFError = (error: GFError | Error): error is GFError => (
-  GF_ERROR_IDENTIFIER_PROP_NAME in error
-)
 
 export const isStackTraceNative = (stackTrace: StackTrace): stackTrace is string => (
   typeof stackTrace === 'string'
@@ -78,7 +72,7 @@ export const createGFError = (options: GFErrorOptions | GFString): GFError => {
 
       return error
     },
-    [GF_ERROR_IDENTIFIER_PROP_NAME]: true,
+    __gfError: true,
   }
 
   return error

--- a/src/good-flow/error/serialize/index.spec.ts
+++ b/src/good-flow/error/serialize/index.spec.ts
@@ -56,18 +56,21 @@ describe('good-flow/error/serialization', () => {
       })
 
       expect(result).toEqual({
+        msg: 'Could not parse configuration',
         advice: {
           tips: [{
             msg: 'Check that configuration file at nonexistent-file.txt exists.',
             url: 'https://github.com/samhuk/good-flow',
           }, 'Check that the configuration file at nonexistent-file.txt is accessible for your user account permissions.'],
         },
-        inner: [{
-          msg: 'Could not read configuration file at nonexistent-file.txt.',
-        }, {
-          msg: 'Could not read configuration file at nonexistent-file.txt.',
-        }],
-        msg: 'Could not parse configuration',
+        inner: [
+          {
+            msg: 'Could not read configuration file at nonexistent-file.txt.',
+          },
+          {
+            msg: 'Could not read configuration file at nonexistent-file.txt.',
+          },
+        ],
       })
     })
   })

--- a/src/good-flow/error/serialize/index.ts
+++ b/src/good-flow/error/serialize/index.ts
@@ -1,17 +1,15 @@
-import { isGFError, isStackTraceNative } from '..'
-import { serializeAdvice } from '../../advice/serialization'
+import { isStackTraceNative } from '..'
+import { serializeAdvice } from '../../advice/serialize'
 import { normalizeGFString } from '../../string'
+import { isGFError } from '../identification'
+import { SerializedStackTrace, SerializedGFErrorOrError, SerializedGFError } from '../serialized/types'
 import { DEFAULT_CUSTOM_STACK_TRACE_RENDERER } from '../toLogString'
-import { GFError, GFErrorInner, GFErrorOrError, StackTrace } from '../types'
+import { StackTrace, GFErrorOrError, GFError } from '../types'
 import {
+  NativeStackTraceSerializer,
   CustomStackTraceSerializer,
   NativeErrorSerializer,
-  NativeStackTraceSerializer,
   ResolvedSerializeGFErrorOptions,
-  SerializedGFError,
-  SerializedGFErrorInner,
-  SerializedGFErrorOrError,
-  SerializedStackTrace,
   SerializeGFErrorOptions,
 } from './types'
 

--- a/src/good-flow/error/serialize/types.ts
+++ b/src/good-flow/error/serialize/types.ts
@@ -1,5 +1,4 @@
 import { CallSite } from 'stack-utils'
-import { SerializedGFAdvice } from '../../advice/serialization/types'
 
 export type NativeStackTraceSerializer = (stack: string) => string | null
 
@@ -42,30 +41,4 @@ export type ResolvedSerializeGFErrorOptions = {
   nativeStackTraceSerializer: NativeStackTraceSerializer | false
   customStackTraceSerializer: CustomStackTraceSerializer | false
   nativeErrorSerializer: NativeErrorSerializer | false
-}
-
-export type SerializedStackTrace = string | string[]
-
-export type SerializedGFErrorOrError = SerializedGFError | Error
-
-export type SerializedGFErrorInner = SerializedGFErrorOrError | SerializedGFErrorOrError[]
-
-export type SerializedGFError = {
-  /**
-   * The message of the error.
-   */
-  msg: string
-  /**
-   * Optional child error(s) of this error. This could either be another `GFError` or
-   * a native Javascript Error or Error-like class.
-   */
-  inner?: SerializedGFErrorInner
-  /**
-   * Optional advice about the error, such as tips on how it could potentially be resolved.
-   */
-  advice?: SerializedGFAdvice
-  /**
-   * Optional stack trace of this error.
-   */
-  stack?: SerializedStackTrace
 }

--- a/src/good-flow/error/serialized/types.ts
+++ b/src/good-flow/error/serialized/types.ts
@@ -1,0 +1,28 @@
+import { SerializedGFAdvice } from '../../advice/serialized/types'
+import { GF_ERROR_IDENTIFIER_PROP_NAME } from '../identification'
+
+export type SerializedStackTrace = string | string[]
+
+export type SerializedGFErrorOrError = SerializedGFError | Error
+
+export type SerializedGFErrorInner = SerializedGFErrorOrError | SerializedGFErrorOrError[]
+
+export type SerializedGFError = {
+  /**
+   * The message of the error.
+   */
+  msg: string
+  /**
+   * Optional child error(s) of this error. This could either be another `GFError` or
+   * a native Javascript Error or Error-like class.
+   */
+  inner?: SerializedGFErrorInner
+  /**
+   * Optional advice about the error, such as tips on how it could potentially be resolved.
+   */
+  advice?: SerializedGFAdvice
+  /**
+   * Optional stack trace of this error.
+   */
+  stack?: SerializedStackTrace
+}

--- a/src/good-flow/error/toLogString/index.ts
+++ b/src/good-flow/error/toLogString/index.ts
@@ -1,10 +1,11 @@
 import colors from 'colors/safe'
 import StackUtils from 'stack-utils'
-import { isGFError, isStackTraceNative } from '..'
+import { isStackTraceNative } from '..'
 import { toLogString as termTreeNodeToLogString } from '../../../term-tree-formatter'
 import { Node, NodeContent } from '../../../term-tree-formatter/types'
 import { ensureArray } from '../../common'
 import { normalizeGFString } from '../../string'
+import { isGFError } from '../identification'
 import { GFError, GFErrorInner, GFErrorOrError, StackTrace } from '../types'
 import { adviceToNodes } from './advice'
 import {
@@ -50,7 +51,9 @@ const singleErrorInnerToNode = (
   ? errorToNode(error, false, options)
   : {
     content: ensureArray(options.nonRootNativeErrorHeaderRenderer(error)).map(gfString => normalizeGFString(gfString))
-      .concat(normalizeStackTraceRendererOutput(options.nativeStackTraceRenderer(error.stack))),
+      .concat(options.nativeStackTraceRenderer === false
+        ? []
+        : normalizeStackTraceRendererOutput(options.nativeStackTraceRenderer(error.stack))),
   })
 
 const errorInnerToNodes = (inner: GFErrorInner, options: ResolvedToLogStringOptions): Node[] => (
@@ -63,8 +66,8 @@ const stackTraceToNodeContent = (
 ): NodeContent => (
   normalizeStackTraceRendererOutput(
     isStackTraceNative(stackTrace)
-      ? options.nativeStackTraceRenderer(stackTrace)
-      : options.customStackTraceRenderer(stackTrace),
+      ? options.nativeStackTraceRenderer === false ? [] : options.nativeStackTraceRenderer(stackTrace)
+      : options.customStackTraceRenderer === false ? [] : options.customStackTraceRenderer(stackTrace),
   )
 )
 

--- a/src/good-flow/error/toLogString/types.ts
+++ b/src/good-flow/error/toLogString/types.ts
@@ -20,7 +20,9 @@ export type ToLogStringOptions = {
    */
   linesBetweenNodes?: number
   /**
-   * Controls the rendering of native stack traces (i.e. from the native Javascript `Error` class).
+   * Controls the rendering of native error stack traces (i.e. from the native Javascript `Error` class).
+   *
+   * Define as `false` to not show at all.
    *
    * To illustrate where this corresponds to and the default rendering:
    * ```text
@@ -31,9 +33,11 @@ export type ToLogStringOptions = {
    * ...
    * ```
    */
-  nativeStackTraceRenderer?: NativeStackTraceRenderer
+  nativeStackTraceRenderer?: NativeStackTraceRenderer | false
   /**
-   * Controls the rendering of custom stack traces (captured with stack-util).
+   * Controls the rendering of GFError stack traces (captured with `stack-util`).
+   *
+   * Define as `false` to not show at all.
    *
    * To illustrate where this corresponds to and the default rendering:
    * ```text
@@ -44,7 +48,7 @@ export type ToLogStringOptions = {
    * ...
    * ```
    */
-  customStackTraceRenderer?: CustomStackTraceRenderer
+  customStackTraceRenderer?: CustomStackTraceRenderer | false
   /**
    * Controls the rendering of the header of the root error.
    *

--- a/src/good-flow/error/toLogString/types.ts
+++ b/src/good-flow/error/toLogString/types.ts
@@ -14,7 +14,7 @@ export type NativeErrorHeaderRenderer = (error: Error) => GFString | GFString[]
 
 export type ToLogStringOptions = {
   /**
-   * Determines how the nodes of your error vertically spaced.
+   * Determines how many lines vertically separate the textual nodes of the error.
    *
    * @default 0 // (No vertical spacing)
    */

--- a/src/good-flow/error/types.ts
+++ b/src/good-flow/error/types.ts
@@ -1,9 +1,10 @@
 import { CallSite } from 'stack-utils'
-import { GF_ERROR_IDENTIFIER_PROP_NAME } from '.'
 import { GFAdvice } from '../advice/types'
 import { GFString } from '../string/types'
-import { SerializedGFError, SerializeGFErrorOptions } from './serialization/types'
+import { SerializedGFError } from './serialized/types'
+import { SerializeGFErrorOptions } from './serialize/types'
 import { ToLogStringOptions } from './toLogString/types'
+import { GF_ERROR_IDENTIFIER_PROP_NAME } from './identification'
 
 export type StackTrace = CallSite[] | string
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,6 @@
  */
 
 export { createGFError } from './good-flow/error'
+export { isGFError } from './good-flow/error/identification'
+
 export * from './types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,10 @@
  * This file defines the public API of the package. Everything here will be available from
  * the top-level package name when importing as an npm package.
  *
- * E.g. `import { createPackageName, PackageNameOptions } from 'npm-package-name`
+ * E.g. `import ... from 'good-flow`
+ *
+ * Note: Importing anything from here will result in the co-importation of the `colors` package,
+ * which is not valid in browser environments.
  */
 
 export { createGFError } from './good-flow/error'

--- a/src/serialized.ts
+++ b/src/serialized.ts
@@ -1,0 +1,9 @@
+/**
+ * This file defines the public API of the serialized side of the package. This does not
+ * include any code that is Node.js-dependant such as the `colors` package.
+ *
+ * Things exported from here are available like so: `import ... from 'good-flow/serialized`
+ */
+
+export type { SerializedGFError, SerializedStackTrace } from './good-flow/error/serialized/types'
+export type { SerializedGFAdvice, SerializedGFTip, SerializedGFTips } from './good-flow/advice/serialized/types'

--- a/src/serialized.ts
+++ b/src/serialized.ts
@@ -5,5 +5,7 @@
  * Things exported from here are available like so: `import ... from 'good-flow/serialized`
  */
 
+export { isSerializedGFError } from './good-flow/error/identification'
+
 export type { SerializedGFError, SerializedStackTrace } from './good-flow/error/serialized/types'
 export type { SerializedGFAdvice, SerializedGFTip, SerializedGFTips } from './good-flow/advice/serialized/types'

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "./tsconfig.json",
-  "include": ["./src/index.ts"],
+  "include": ["./src/index.ts", "./src/serialized.ts"],
   "compilerOptions": {
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
This PR:
* Separates out the code used for serialized types so that they can be imported stand-alone (without co-importing Node.js-only code such as the `colors` package).
* Improves various JSDocs.
* Improves the README, adding some more detail about functionality.
* Some minor niggles here and there.